### PR TITLE
Improve loading indicator.

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -102,9 +102,10 @@ filter: progid:DXImageTransform.Microsoft.gradient(startColorstr="#009564",endCo
   width: 80px;
   height: 80px;
   margin: auto;
-  background: black;
+  /* background: black; */
   border-radius: 10px;
-  opacity: 0.3;
+  /* opacity: 0.3; */
+  filter: drop-shadow(1px 1px 0px black);
 }
 .loadingIndicator.active {
   display: block;

--- a/public/style.css
+++ b/public/style.css
@@ -102,9 +102,7 @@ filter: progid:DXImageTransform.Microsoft.gradient(startColorstr="#009564",endCo
   width: 80px;
   height: 80px;
   margin: auto;
-  /* background: black; */
   border-radius: 10px;
-  /* opacity: 0.3; */
   filter: drop-shadow(1px 1px 0px black);
 }
 .loadingIndicator.active {

--- a/public/style.css
+++ b/public/style.css
@@ -103,7 +103,7 @@ filter: progid:DXImageTransform.Microsoft.gradient(startColorstr="#009564",endCo
   height: 80px;
   margin: auto;
   border-radius: 10px;
-  filter: drop-shadow(1px 1px 0px black);
+  filter: drop-shadow(1px 1px 2px black);
 }
 .loadingIndicator.active {
   display: block;

--- a/src/components/LoadingOverlay.jsx
+++ b/src/components/LoadingOverlay.jsx
@@ -7,8 +7,8 @@ import {ViewContext} from "../context/ViewContext"
 export default function LoadingOverlayCircularStatic({
   title = "LOADING"
 }) {
-  const {loading} = useContext(ViewContext)
-  // return loading ? (
+  const {isLoading} = useContext(ViewContext)
+  // return isLoading ? (
   //   <div className={styles['LoadingStyleBox']}>
   //   <span className={styles["loading-spinner"]} />
   //     <span className = {styles["loading-text"]} >{title}</span>
@@ -17,7 +17,7 @@ export default function LoadingOverlayCircularStatic({
   //     </div>
   //   </div>
   // ) : null
-  return loading ? (
+  return isLoading ? (
     <div className={styles['LoadingStyleBox']}>
       <span className={styles["loading-spinner"]} />
       <span className = {styles["loading-text"]} >{title}</span>

--- a/src/components/LoadingOverlay.jsx
+++ b/src/components/LoadingOverlay.jsx
@@ -1,5 +1,5 @@
 import React, {useContext} from "react"
-import webaMark from "../../public/ui/loading/webaMark.svg"
+// import webaMark from "../../public/ui/loading/webaMark.svg"
 
 import styles from './LoadingOverlay.module.css'
 
@@ -8,13 +8,19 @@ export default function LoadingOverlayCircularStatic({
   title = "LOADING"
 }) {
   const {loading} = useContext(ViewContext)
+  // return loading ? (
+  //   <div className={styles['LoadingStyleBox']}>
+  //   <span className={styles["loading-spinner"]} />
+  //     <span className = {styles["loading-text"]} >{title}</span>
+  //     <div className={styles["logo-container"]}>
+  //         <img className={styles["webamark"]} src={webaMark} />
+  //     </div>
+  //   </div>
+  // ) : null
   return loading ? (
     <div className={styles['LoadingStyleBox']}>
-    <span className={styles["loading-spinner"]} />
+      <span className={styles["loading-spinner"]} />
       <span className = {styles["loading-text"]} >{title}</span>
-      <div className={styles["logo-container"]}>
-          <img className={styles["webamark"]} src={webaMark} />
-      </div>
     </div>
   ) : null
 }

--- a/src/components/LoadingOverlay.module.css
+++ b/src/components/LoadingOverlay.module.css
@@ -14,7 +14,6 @@
     user-select: none;
     overflow: hidden;
     background: #000000;
-    /* background: none; */
 }
 
 .loading-text {

--- a/src/components/LoadingOverlay.module.css
+++ b/src/components/LoadingOverlay.module.css
@@ -14,6 +14,7 @@
     user-select: none;
     overflow: hidden;
     background: #000000;
+    /* background: none; */
 }
 
 .loading-text {

--- a/src/components/Selector.jsx
+++ b/src/components/Selector.jsx
@@ -641,11 +641,9 @@ export default function Selector({templateInfo, animationManager, blinkManager, 
                         : styles["tickStyleInActive"]
                     }
                   />
-                  {active && loadPercentage > 0 && loadPercentage < 100 && (
-                    <div className={styles["loading-trait"]}>
-                      {loadPercentage}
-                    </div>
-                  )}
+                  {/*{active && loadPercentage > 0 && loadPercentage < 100 && (
+                    // TODO: Fill up background from bottom as loadPercentage increases
+                  )}*/}
                 </div>
               )
             })}

--- a/src/components/Selector.jsx
+++ b/src/components/Selector.jsx
@@ -50,6 +50,7 @@ export default function Selector({templateInfo, animationManager, blinkManager, 
   } = useContext(SoundContext)
   const { isMute } = useContext(AudioContext)
   const {loading, setLoading} = useContext(ViewContext)
+  const {setEffecting} = useContext(ViewContext)
 
   const [selectValue, setSelectValue] = useState("0")
   const [loadPercentage, setLoadPercentage] = useState(1)
@@ -211,6 +212,7 @@ export default function Selector({templateInfo, animationManager, blinkManager, 
     }
 
     setLoading(true);
+    setEffecting(true);
 
     //create the manager for all the options
     const loadingManager = new THREE.LoadingManager()

--- a/src/components/Selector.jsx
+++ b/src/components/Selector.jsx
@@ -49,8 +49,8 @@ export default function Selector({templateInfo, animationManager, blinkManager, 
     playSound
   } = useContext(SoundContext)
   const { isMute } = useContext(AudioContext)
-  const {loading, setLoading} = useContext(ViewContext)
-  const {setEffecting} = useContext(ViewContext)
+  const {isLoading, setIsLoading} = useContext(ViewContext)
+  const {setIsPlayingEffect} = useContext(ViewContext)
 
   const [selectValue, setSelectValue] = useState("0")
   const [loadPercentage, setLoadPercentage] = useState(1)
@@ -59,11 +59,11 @@ export default function Selector({templateInfo, animationManager, blinkManager, 
   useEffect(() => {
     //setSelectedOptions (getMultipleRandomTraits(initialTraits))
     setRestrictions(getRestrictions());
-    
+
   },[templateInfo])
 
   const getRestrictions = () => {
-    
+
     const traitRestrictions = templateInfo.traitRestrictions
     const typeRestrictions = {};
 
@@ -154,7 +154,7 @@ export default function Selector({templateInfo, animationManager, blinkManager, 
   },[selectedOptions])
   // user selects an option
   const selectTraitOption = (option) => {
-    if (loading) return;
+    if (isLoading) return;
 
     if (option == null){
       option = {
@@ -162,7 +162,7 @@ export default function Selector({templateInfo, animationManager, blinkManager, 
         trait:templateInfo.traits.find((t) => t.name === currentTraitName)
       }
     }
-    
+
     if (option.avatarIndex != null){
       if(isNewClass(option.avatarIndex)){
         selectClass(option.avatarIndex)
@@ -211,8 +211,8 @@ export default function Selector({templateInfo, animationManager, blinkManager, 
       });
     }
 
-    setLoading(true);
-    setEffecting(true);
+    setIsLoading(true);
+    setIsPlayingEffect(true);
 
     //create the manager for all the options
     const loadingManager = new THREE.LoadingManager()
@@ -236,7 +236,7 @@ export default function Selector({templateInfo, animationManager, blinkManager, 
       loadingManager.onLoad = function (){
         setLoadPercentage(0)
         resolve(resultData);
-        setLoading(false)
+        setIsLoading(false)
       };
       loadingManager.onError = function (url){
         console.warn("error loading " + url)
@@ -246,7 +246,7 @@ export default function Selector({templateInfo, animationManager, blinkManager, 
       }
 
       const baseDir = templateInfo.traitsDirectory// (maybe set in loading manager)
-      
+
       // load necesary assets for the options
       options.map((option, index)=>{
         setSelectValue(option.key)

--- a/src/components/Selector.jsx
+++ b/src/components/Selector.jsx
@@ -44,14 +44,12 @@ export default function Selector({templateInfo, animationManager, blinkManager, 
     mousePosition,
     removeOption,
     saveUserSelection,
-    isLoading,
-    setIsLoading,
   } = useContext(SceneContext)
   const {
     playSound
   } = useContext(SoundContext)
   const { isMute } = useContext(AudioContext)
-  const {setLoading} = useContext(ViewContext)
+  const {loading, setLoading} = useContext(ViewContext)
 
   const [selectValue, setSelectValue] = useState("0")
   const [loadPercentage, setLoadPercentage] = useState(1)
@@ -155,7 +153,7 @@ export default function Selector({templateInfo, animationManager, blinkManager, 
   },[selectedOptions])
   // user selects an option
   const selectTraitOption = (option) => {
-    if (isLoading) return;
+    if (loading) return;
 
     if (option == null){
       option = {
@@ -212,7 +210,7 @@ export default function Selector({templateInfo, animationManager, blinkManager, 
       });
     }
 
-    setIsLoading(true);
+    setLoading(true);
 
     //create the manager for all the options
     const loadingManager = new THREE.LoadingManager()

--- a/src/components/Selector.module.css
+++ b/src/components/Selector.module.css
@@ -168,36 +168,6 @@
   display: none;
 }
 
-.loading-trait {
-  height: 4em;
-  width: 4em;
-  text-align: center;
-  line-height: 52px;
-  background-color: rgba(16, 16, 16, 0.3);
-  border-radius: 1em;
-  z-index: 999;
-  position: absolute;
-  display: block;
-  color: #efefef;
-  top: 0;
-  cursor: wait;
-}
-
 .icon-hidden {
   visibility: hidden;
-}
-
-.loading-trait-overlay {
-  position: fixed;
-  left: 0;
-  top: 0;
-  width: 100%;
-  height: 98%;
-  background-color: rgba(16, 16, 16, 0.3);
-  border-radius: 1em;
-  cursor: wait;
-}
-
-.loading-trait-overlay-show {
-  display: none;
 }

--- a/src/context/SceneContext.jsx
+++ b/src/context/SceneContext.jsx
@@ -56,8 +56,6 @@ export const SceneProvider = (props) => {
   const [manifest, setManifest] = useState(null)
   const [sceneModel, setSceneModel] = useState(null)
 
-  const [isLoading, setIsLoading] = useState(false)
-
   const setAvatar = (state) => {
     _setAvatar(state)
   }
@@ -198,8 +196,6 @@ export const SceneProvider = (props) => {
         initializeScene,
         mousePosition, 
         setMousePosition,
-        isLoading,
-        setIsLoading,
       }}
     >
       {props.children}

--- a/src/context/ViewContext.jsx
+++ b/src/context/ViewContext.jsx
@@ -23,7 +23,7 @@ export const ViewContext = React.createContext()
 export const ViewProvider = (props) => {
   const [currentCameraMode, setCurrentCameraMode] = React.useState(CameraMode.NORMAL)
   const [viewMode, setViewMode] = React.useState(ViewMode.LANDING)
-  const [loading, setLoading] = React.useState(true)
+  const [loading, setLoading] = React.useState(false)
   const [mouseIsOverUI, setMouseIsOverUI] = React.useState(false)
   return (
     <ViewContext.Provider value={{

--- a/src/context/ViewContext.jsx
+++ b/src/context/ViewContext.jsx
@@ -23,15 +23,15 @@ export const ViewContext = React.createContext()
 export const ViewProvider = (props) => {
   const [currentCameraMode, setCurrentCameraMode] = React.useState(CameraMode.NORMAL)
   const [viewMode, setViewMode] = React.useState(ViewMode.LANDING)
-  const [loading, setLoading] = React.useState(false)
-  const [effecting, setEffecting] = React.useState(false)
+  const [isLoading, setIsLoading] = React.useState(false)
+  const [isPlayingEffect, setIsPlayingEffect] = React.useState(false)
   const [mouseIsOverUI, setMouseIsOverUI] = React.useState(false)
   return (
     <ViewContext.Provider value={{
       currentCameraMode, setCurrentCameraMode,
       viewMode, setViewMode,
-      loading, setLoading,
-      effecting, setEffecting,
+      isLoading, setIsLoading,
+      isPlayingEffect, setIsPlayingEffect,
       mouseIsOverUI, setMouseIsOverUI
     }}>
       {props.children}

--- a/src/context/ViewContext.jsx
+++ b/src/context/ViewContext.jsx
@@ -24,12 +24,14 @@ export const ViewProvider = (props) => {
   const [currentCameraMode, setCurrentCameraMode] = React.useState(CameraMode.NORMAL)
   const [viewMode, setViewMode] = React.useState(ViewMode.LANDING)
   const [loading, setLoading] = React.useState(false)
+  const [effecting, setEffecting] = React.useState(false)
   const [mouseIsOverUI, setMouseIsOverUI] = React.useState(false)
   return (
     <ViewContext.Provider value={{
       currentCameraMode, setCurrentCameraMode,
       viewMode, setViewMode,
       loading, setLoading,
+      effecting, setEffecting,
       mouseIsOverUI, setMouseIsOverUI
     }}>
       {props.children}

--- a/src/pages/Appearance.jsx
+++ b/src/pages/Appearance.jsx
@@ -8,17 +8,17 @@ import CustomButton from '../components/custom-button'
 function Appearance({manifest, initialTraits, animationManager, blinkManager, effectManager, fetchNewModel}) {
     const { setViewMode } = React.useContext(ViewContext);
     const { resetAvatar, getRandomCharacter } = React.useContext(SceneContext)
-    const { loading, effecting, setEffecting } = React.useContext(ViewContext)
+    const { isLoading, isPlayingEffect, setIsPlayingEffect } = React.useContext(ViewContext)
     const back = () => {
         console.log('back 1');
         resetAvatar();
         setViewMode(ViewMode.CREATE)
     }
     effectManager.addEventListener('fadeintraitend', () => {
-        setEffecting(false);
+        setIsPlayingEffect(false);
     })
     effectManager.addEventListener('fadeinavatarend', () => {
-        setEffecting(false);
+        setIsPlayingEffect(false);
     })
 
     const next = () => {
@@ -27,14 +27,14 @@ function Appearance({manifest, initialTraits, animationManager, blinkManager, ef
     }
 
     const randomize = () => {
-        if (!effecting) {
+        if (!isPlayingEffect) {
             getRandomCharacter()
         }
     }
 
     return (
         <div className={styles.container}>
-            <div className={`loadingIndicator ${loading?"active":""}`}>
+            <div className={`loadingIndicator ${isLoading?"active":""}`}>
                 <img className={"rotate"} src="ui/loading.svg"/>
             </div>
             <div className={"sectionTitle"}>Choose Appearance</div>

--- a/src/pages/Appearance.jsx
+++ b/src/pages/Appearance.jsx
@@ -7,17 +7,18 @@ import CustomButton from '../components/custom-button'
 
 function Appearance({manifest, initialTraits, animationManager, blinkManager, effectManager, fetchNewModel}) {
     const { setViewMode } = React.useContext(ViewContext);
-    const { resetAvatar, getRandomCharacter, isLoading, setIsLoading } = React.useContext(SceneContext)
+    const { resetAvatar, getRandomCharacter } = React.useContext(SceneContext)
+    const { loading, setLoading } = React.useContext(ViewContext)
     const back = () => {
         console.log('back 1');
         resetAvatar();
         setViewMode(ViewMode.CREATE)
     }
     effectManager.addEventListener('fadeintraitend', () => {
-        setIsLoading(false);
+        setLoading(false);
     })
     effectManager.addEventListener('fadeinavatarend', () => {
-        setIsLoading(false);
+        setLoading(false);
     })
 
     const next = () => {
@@ -26,14 +27,14 @@ function Appearance({manifest, initialTraits, animationManager, blinkManager, ef
     }
 
     const randomize = () => {
-        if (!isLoading) {
+        if (!loading) {
             getRandomCharacter()
         }
     }
 
     return (
         <div className={styles.container}>
-            <div className={`loadingIndicator ${isLoading?"active":""}`}>
+            <div className={`loadingIndicator ${loading?"active":""}`}>
                 <img className={"rotate"} src="ui/loading.svg"/>
             </div>
             <div className={"sectionTitle"}>Choose Appearance</div>

--- a/src/pages/Appearance.jsx
+++ b/src/pages/Appearance.jsx
@@ -8,17 +8,17 @@ import CustomButton from '../components/custom-button'
 function Appearance({manifest, initialTraits, animationManager, blinkManager, effectManager, fetchNewModel}) {
     const { setViewMode } = React.useContext(ViewContext);
     const { resetAvatar, getRandomCharacter } = React.useContext(SceneContext)
-    const { loading, setLoading } = React.useContext(ViewContext)
+    const { loading, effecting, setEffecting } = React.useContext(ViewContext)
     const back = () => {
         console.log('back 1');
         resetAvatar();
         setViewMode(ViewMode.CREATE)
     }
     effectManager.addEventListener('fadeintraitend', () => {
-        setLoading(false);
+        setEffecting(false);
     })
     effectManager.addEventListener('fadeinavatarend', () => {
-        setLoading(false);
+        setEffecting(false);
     })
 
     const next = () => {
@@ -27,7 +27,7 @@ function Appearance({manifest, initialTraits, animationManager, blinkManager, ef
     }
 
     const randomize = () => {
-        if (!loading) {
+        if (!effecting) {
             getRandomCharacter()
         }
     }


### PR DESCRIPTION
Follow https://github.com/webaverse-studios/CharacterCreator/pull/232

- Remove indicator's background, add shadow.
- Found there's existing `loading` state, use it to show/hide indicator, remove newly add `isLoading`.
  There's also existing `LoadingOverlay` page, but tried that looks not well with current UI, so keep using new loading indicator.
- Add `effecting` state. We don't want see indicator when playing VFX, but still can't allow user change traits when playing VFX, so have to add `effecting` state.

https://user-images.githubusercontent.com/10785634/215502684-e380ba7d-2230-4370-b162-4df8512a1a02.mp4

