### PR TITLE
Fix trait thumbnail color.

### DIFF
--- a/src/library/option-utils.js
+++ b/src/library/option-utils.js
@@ -91,7 +91,7 @@ export function getTraitOptions(trait, template) {
             trait,
             item,
             thumbnailBaseDir + thumbnail,
-            getHSL(colorTrait.value[0], colorTrait.iconSaturation),
+            getHSL(colorTrait.value[0]),
             null,
             colorTrait,
           ),
@@ -121,11 +121,49 @@ function getOption(
     colorTrait,
   }
 }
-function getHSL (hex, overrideSaturation){
+function getHSL (hex){ // getHSV
+  /* note: 
+    Web standards need HSV instead of HSL, so in fact this function return **HSV**, but to compatible with old codes, still named getHSL.
+    Codes from: https://stackoverflow.com/a/8023734/3596736
+    Related infos:
+    https://www.rapidtables.com/convert/color/rgb-to-hsv.html
+    https://www.rapidtables.com/convert/color/rgb-to-hsl.html
+    https://github.com/mrdoob/three.js/pull/3109
+    https://gist.github.com/xpansive/1337890#file-index-js
+  */
   const color = new THREE.Color(hex)
   const hsl = { h: 0, s: 0, l: 0 }
-  color.getHSL(hsl)
-  hsl.s = overrideSaturation ? overrideSaturation : hsl.s
+  let rabs, gabs, babs, rr, gg, bb, h, s, v, diff, diffc;
+  rabs = color.r;
+  gabs = color.g;
+  babs = color.b;
+  v = Math.max(rabs, gabs, babs),
+  diff = v - Math.min(rabs, gabs, babs);
+  diffc = c => (v - c) / 6 / diff + 1 / 2;
+  if (diff == 0) {
+      h = s = 0;
+  } else {
+      s = diff / v;
+      rr = diffc(rabs);
+      gg = diffc(gabs);
+      bb = diffc(babs);
+
+      if (rabs === v) {
+          h = bb - gg;
+      } else if (gabs === v) {
+          h = (1 / 3) + rr - bb;
+      } else if (babs === v) {
+          h = (2 / 3) + gg - rr;
+      }
+      if (h < 0) {
+          h += 1;
+      }else if (h > 1) {
+          h -= 1;
+      }
+  }
+  hsl.h = h;
+  hsl.s = s;
+  hsl.l = v;
   return hsl
 }
 


### PR DESCRIPTION
Fix https://github.com/webaverse-studios/CharacterCreator/issues/248

![image](https://user-images.githubusercontent.com/10785634/215832849-52a7cfe7-e55a-43e3-904b-e21d6d6f501a.png)

Turned out that web standards need HSV instead of HSL, so in fact now this function return **HSV**, but to compatible with old codes, still named getHSL.

Codes from: https://stackoverflow.com/a/8023734/3596736

Related infos:
https://github.com/mrdoob/three.js/pull/3109
https://gist.github.com/xpansive/1337890#file-index-js

https://www.rapidtables.com/convert/color/rgb-to-hsv.html
![image](https://user-images.githubusercontent.com/10785634/215842616-d4bb5239-70d6-464f-b16b-50c5b5979533.png)

https://www.rapidtables.com/convert/color/rgb-to-hsl.html
![image](https://user-images.githubusercontent.com/10785634/215842650-cc7ac833-dadd-4587-973d-485a4dac634b.png)
