### PR TITLE
compute transition time instead of using constant

### DIFF
--- a/src/library/effectManager.js
+++ b/src/library/effectManager.js
@@ -288,7 +288,7 @@ export class EffectManager extends EventTarget{
     this.particleEffect.emitPixel();
     this.particleEffect.emitTeleport();
     this.particleEffect.emitSpotLight();
-    this.transitionTime = TRANSITION_TIME_OF_LOADING_AVATAR;
+    this.transitionTime = this.frameRate * ((FADE_OUT_AVATAR_DURATION - FADE_OUT_AVATAR_INITIAL_TIME) / FADE_OUT_AVATAR_SPEED);
     this.initialFadeOutTimer();
   }
 


### PR DESCRIPTION
Now we are using constant for fade-in transition time which cause the latency of fade-in effect that is because we add the model to the scene before the effect is finished. In this pr, I compute the transition time instead of using constant.

issue: 


https://user-images.githubusercontent.com/60634884/215914217-41bf4cca-88fa-43dc-bb37-42958fee2f23.mp4

result:


https://user-images.githubusercontent.com/60634884/215914234-d7ee5336-b47e-48b4-b918-542f93c96064.mp4

