### PR TITLE
Look at manager to reset character view

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -94,7 +94,7 @@ async function fetchAll() {
   const sceneModel = await fetchScene()
 
   const blinkManager = new BlinkManager(0.1, 0.1, 0.5, 5)
-  const lookatManager = new LookAtManager()
+  const lookatManager = new LookAtManager(50)
   const effectManager = new EffectManager()
 
   return {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -94,7 +94,7 @@ async function fetchAll() {
   const sceneModel = await fetchScene()
 
   const blinkManager = new BlinkManager(0.1, 0.1, 0.5, 5)
-  const lookatManager = new LookAtManager(50)
+  const lookatManager = new LookAtManager(65)
   const effectManager = new EffectManager()
 
   return {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -297,7 +297,7 @@ export default function App() {
         Character Creator
       </div>
       <Background />
-      <Scene manifest={manifest} sceneModel={sceneModel} />
+      <Scene manifest={manifest} sceneModel={sceneModel} lookatManager ={lookatManager}  />
       {pages[viewMode]}
     </Fragment>
   )

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -233,6 +233,12 @@ export default function App() {
   
   useEffect(() => {
     updateCameraPosition();
+    if ([ViewMode.BIO, ViewMode.MINT, ViewMode.CHAT].includes(viewMode)){
+      lookatManager.enabled = false;
+    }
+    else{
+      lookatManager.enabled = true;
+    }
     window.addEventListener('resize', updateCameraPosition);
     return () => {
       window.removeEventListener('resize', updateCameraPosition);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader"
 import { ViewMode, ViewContext } from "./context/ViewContext"
 
 import { AnimationManager } from "./library/animationManager"
+import { LookAtManager } from "./library/lookatManager"
 import { BlinkManager } from "./library/blinkManager"
 import { getAsArray } from "./library/utils"
 import Background from "./components/Background"
@@ -93,6 +94,7 @@ async function fetchAll() {
   const sceneModel = await fetchScene()
 
   const blinkManager = new BlinkManager(0.1, 0.1, 0.5, 5)
+  const lookatManager = new LookAtManager()
   const effectManager = new EffectManager()
 
   return {
@@ -100,6 +102,7 @@ async function fetchAll() {
     personality,
     sceneModel,
     blinkManager,
+    lookatManager,
     effectManager,
   }
 }
@@ -140,6 +143,7 @@ export default function App() {
     personality,
     sceneModel,
     blinkManager,
+    lookatManager,
     effectManager,
   } = resource.read()
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -273,6 +273,7 @@ export default function App() {
         manifest={manifest}
         animationManager={animationManager}
         blinkManager={blinkManager}
+        lookatManager={lookatManager}
         effectManager={effectManager}
         fetchNewModel={fetchNewModel}
       />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -94,7 +94,7 @@ async function fetchAll() {
   const sceneModel = await fetchScene()
 
   const blinkManager = new BlinkManager(0.1, 0.1, 0.5, 5)
-  const lookatManager = new LookAtManager(80)
+  const lookatManager = new LookAtManager(80, "editor-scene")
   const effectManager = new EffectManager()
 
   return {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -94,7 +94,7 @@ async function fetchAll() {
   const sceneModel = await fetchScene()
 
   const blinkManager = new BlinkManager(0.1, 0.1, 0.5, 5)
-  const lookatManager = new LookAtManager(65)
+  const lookatManager = new LookAtManager(80)
   const effectManager = new EffectManager()
 
   return {

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -17,7 +17,7 @@ import Selector from "./Selector"
 import { TokenBox } from "./token-box/TokenBox"
 
 
-export default function Editor({manifest, animationManager, blinkManager, effectManager, fetchNewModel}) {
+export default function Editor({manifest, animationManager, blinkManager, lookatManager, effectManager, fetchNewModel}) {
   const {currentTraitName, setCurrentTraitName, awaitDisplay, setCurrentOptions, setSelectedOptions, setAwaitDisplay, setRemoveOption, loadUserSelection, templateInfo, moveCamera} = useContext(SceneContext);
   
   const { isMute } = useContext(AudioContext)
@@ -124,7 +124,7 @@ export default function Editor({manifest, animationManager, blinkManager, effect
           </div>
         </div>
       </div>
-      <Selector animationManager={animationManager} templateInfo={templateInfo} blinkManager = {blinkManager} effectManager = {effectManager} selectClass = {selectClass} isNewClass = {isNewClass}/>
+      <Selector animationManager={animationManager} templateInfo={templateInfo} blinkManager = {blinkManager} lookatManager = {lookatManager} effectManager = {effectManager} selectClass = {selectClass} isNewClass = {isNewClass}/>
     </Fragment>
   )
 }

--- a/src/components/Scene.jsx
+++ b/src/components/Scene.jsx
@@ -4,7 +4,7 @@ import { SceneContext } from "../context/SceneContext"
 import { CameraMode } from "../context/ViewContext"
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls"
 
-export default function Scene({sceneModel}) {
+export default function Scene({sceneModel, lookatManager}) {
   const {
     scene,
     model, setModel,
@@ -43,7 +43,7 @@ export default function Scene({sceneModel}) {
     )
 
     setCamera(camera)
-
+    lookatManager.setCamera(camera)
     // set the camera position
     camera.position.set(0, 1.3, 2)
 

--- a/src/components/Scene.jsx
+++ b/src/components/Scene.jsx
@@ -94,6 +94,7 @@ export default function Scene({sceneModel, lookatManager}) {
       requestAnimationFrame(animate)
       if (currentCameraMode !== CameraMode.AR) {
         controls?.update()
+        lookatManager.update();
         renderer.render(scene, camera)
       }
     }

--- a/src/components/Scene.jsx
+++ b/src/components/Scene.jsx
@@ -9,89 +9,15 @@ export default function Scene({sceneModel}) {
     scene,
     model, setModel,
     currentCameraMode,
-    traitsSpines,
-    traitsNecks,
-    traitsLeftEye,
-    traitsRightEye,
     setControls,
     setMousePosition,
     setCamera,
   } = useContext(SceneContext)
-  const maxLookPercent = {
-    neck: 20,
-    spine: 5,
-    left: 20,
-    right: 20,
-  }
-
-  const getMouseDegrees = (x, y, degreeLimit) => {
-    let dx = 0,
-      dy = 0,
-      xdiff,
-      xPercentage,
-      ydiff,
-      yPercentage
-
-    let w = { x: window.innerWidth, y: window.innerHeight }
-
-    if (x <= w.x / 2) {
-      // 2. Get the difference between middle of screen and cursor position
-      xdiff = w.x / 2 - x
-      // 3. Find the percentage of that difference (percentage toward edge of screen)
-      xPercentage = (xdiff / (w.x / 2)) * 100
-      // 4. Convert that to a percentage of the maximum rotation we allow for the neck
-      dx = ((degreeLimit * xPercentage) / 100) * -1
-    }
-    if (x >= w.x / 2) {
-      xdiff = x - w.x / 2
-      xPercentage = (xdiff / (w.x / 2)) * 100
-      dx = (degreeLimit * xPercentage) / 100
-    }
-    if (y <= w.y / 2) {
-      ydiff = w.y / 2 - y
-      yPercentage = (ydiff / (w.y / 2)) * 100
-      // Note that I cut degreeLimit in half when she looks up
-      dy = ((degreeLimit * 0.5 * yPercentage) / 100) * -1
-    }
-    if (y >= w.y / 2) {
-      ydiff = y - w.y / 2
-      yPercentage = (ydiff / (w.y / 2)) * 100
-      dy = (degreeLimit * yPercentage) / 100
-    }
-    return { x: dx, y: dy }
-  }
-
+  
   const handleMouseMove = (event) => {
     setMousePosition({x: event.x, y: event.y});
-    const moveJoint = (mouse, joint, degreeLimit) => {
-      if (Object.keys(joint).length !== 0) {
-        let degrees = getMouseDegrees(mouse.x, mouse.y, degreeLimit)
-        joint.rotation.y = THREE.MathUtils.degToRad(degrees.x)
-        joint.rotation.x = THREE.MathUtils.degToRad(degrees.y)
-      }
-    }
-
-    if (
-      traitsNecks.length !== 0 &&
-      traitsSpines.length !== 0 &&
-      traitsLeftEye.length !== 0 &&
-      traitsLeftEye !== 0
-    ) {
-      traitsNecks.map((neck) => {
-        moveJoint(event, neck, maxLookPercent.neck)
-      })
-      traitsSpines.map((spine) => {
-        moveJoint(event, spine, maxLookPercent.spine)
-      })
-      traitsLeftEye.map((leftEye) => {
-        moveJoint(event, leftEye, maxLookPercent.left)
-      })
-      traitsRightEye.map((rightEye) => {
-        moveJoint(event, rightEye, maxLookPercent.right)
-      })
-    }
   }
-  
+
   useEffect(() => {
     window.addEventListener("mousemove", handleMouseMove)
     return () => window.removeEventListener("mousemove", handleMouseMove)

--- a/src/components/Selector.jsx
+++ b/src/components/Selector.jsx
@@ -444,7 +444,7 @@ export default function Selector({templateInfo, animationManager, blinkManager, 
           if (child.isSkinnedMesh) createBoneDirection(child)
         }
         if (child.isBone && child.name == 'neck') { 
-          setTraitsNecks(current => [...current , child])
+          //setTraitsNecks(current => [...current , child])
         }
         if (child.isBone && child.name == 'spine') { 
           setTraitsSpines(current => [...current , child])

--- a/src/components/Selector.jsx
+++ b/src/components/Selector.jsx
@@ -445,18 +445,18 @@ export default function Selector({templateInfo, animationManager, blinkManager, 
           createFaceNormals(child.geometry)
           if (child.isSkinnedMesh) createBoneDirection(child)
         }
-        if (child.isBone && child.name == 'neck') { 
-          setTraitsNecks(current => [...current , child])
-        }
-        if (child.isBone && child.name == 'spine') { 
-          setTraitsSpines(current => [...current , child])
-        }
-        if (child.isBone && child.name === 'leftEye') { 
-          setTraitsLeftEye(current => [...current , child])
-        }
-        if (child.isBone && child.name === 'rightEye') { 
-          setTraitsRightEye(current => [...current , child])
-        }
+        // if (child.isBone && child.name == 'neck') { 
+        //   setTraitsNecks(current => [...current , child])
+        // }
+        // if (child.isBone && child.name == 'spine') { 
+        //   setTraitsSpines(current => [...current , child])
+        // }
+        // if (child.isBone && child.name === 'leftEye') { 
+        //   setTraitsLeftEye(current => [...current , child])
+        // }
+        // if (child.isBone && child.name === 'rightEye') { 
+        //   setTraitsRightEye(current => [...current , child])
+        // }
       })
 
       // culling layers setup section

--- a/src/components/Selector.jsx
+++ b/src/components/Selector.jsx
@@ -27,7 +27,7 @@ THREE.BufferGeometry.prototype.computeBoundsTree = computeBoundsTree;
 THREE.BufferGeometry.prototype.disposeBoundsTree = disposeBoundsTree;
 THREE.Mesh.prototype.raycast = acceleratedRaycast;
 
-export default function Selector({templateInfo, animationManager, blinkManager, isNewClass, effectManager, selectClass}) {
+export default function Selector({templateInfo, animationManager, blinkManager, lookatManager, isNewClass, effectManager, selectClass}) {
   const {
     avatar,
     setAvatar,
@@ -408,6 +408,8 @@ export default function Selector({templateInfo, animationManager, blinkManager, 
       if (getAsArray(templateInfo.blinkerTraits).indexOf(traitData.trait) !== -1)
         blinkManager.addBlinker(vrm)
 
+      lookatManager.testCall()
+
       // animation setup section
       // play animations on this vrm  TODO, letscreate a single animation manager per traitInfo, as model may change since it is now a trait option
       animationManager.startAnimation(vrm)
@@ -444,7 +446,7 @@ export default function Selector({templateInfo, animationManager, blinkManager, 
           if (child.isSkinnedMesh) createBoneDirection(child)
         }
         if (child.isBone && child.name == 'neck') { 
-          //setTraitsNecks(current => [...current , child])
+          setTraitsNecks(current => [...current , child])
         }
         if (child.isBone && child.name == 'spine') { 
           setTraitsSpines(current => [...current , child])

--- a/src/components/Selector.jsx
+++ b/src/components/Selector.jsx
@@ -408,7 +408,7 @@ export default function Selector({templateInfo, animationManager, blinkManager, 
       if (getAsArray(templateInfo.blinkerTraits).indexOf(traitData.trait) !== -1)
         blinkManager.addBlinker(vrm)
 
-      lookatManager.testCall()
+      lookatManager.addVRM(vrm)
 
       // animation setup section
       // play animations on this vrm  TODO, letscreate a single animation manager per traitInfo, as model may change since it is now a trait option

--- a/src/components/Selector.jsx
+++ b/src/components/Selector.jsx
@@ -36,10 +36,6 @@ export default function Selector({templateInfo, animationManager, blinkManager, 
     selectedOptions,
     setSelectedOptions,
     model,
-    setTraitsNecks,
-    setTraitsSpines,
-    setTraitsLeftEye,
-    setTraitsRightEye,
     setLipSync,
     mousePosition,
     removeOption,
@@ -445,18 +441,6 @@ export default function Selector({templateInfo, animationManager, blinkManager, 
           createFaceNormals(child.geometry)
           if (child.isSkinnedMesh) createBoneDirection(child)
         }
-        // if (child.isBone && child.name == 'neck') { 
-        //   setTraitsNecks(current => [...current , child])
-        // }
-        // if (child.isBone && child.name == 'spine') { 
-        //   setTraitsSpines(current => [...current , child])
-        // }
-        // if (child.isBone && child.name === 'leftEye') { 
-        //   setTraitsLeftEye(current => [...current , child])
-        // }
-        // if (child.isBone && child.name === 'rightEye') { 
-        //   setTraitsRightEye(current => [...current , child])
-        // }
       })
 
       // culling layers setup section

--- a/src/context/SceneContext.jsx
+++ b/src/context/SceneContext.jsx
@@ -35,10 +35,6 @@ export const SceneProvider = (props) => {
   const [awaitDisplay, setAwaitDisplay] = useState(false)
 
   const [colorStatus, setColorStatus] = useState("")
-  const [traitsNecks, setTraitsNecks] = useState([])
-  const [traitsSpines, setTraitsSpines] = useState([])
-  const [traitsLeftEye, setTraitsLeftEye] = useState([])
-  const [traitsRightEye, setTraitsRightEye] = useState([])
   const [skinColor, setSkinColor] = useState(new THREE.Color(1, 1, 1))
   const [avatar, _setAvatar] = useState(null)
 
@@ -185,16 +181,8 @@ export const SceneProvider = (props) => {
         setAvatar,
         resetAvatar,
         moveCamera,
-        traitsNecks,
-        setTraitsNecks,
-        traitsSpines,
-        setTraitsSpines,
         controls,
         setControls,
-        traitsLeftEye,
-        setTraitsLeftEye,
-        traitsRightEye,
-        setTraitsRightEye,
         initializeScene,
         mousePosition, 
         setMousePosition,

--- a/src/library/lookatManager.js
+++ b/src/library/lookatManager.js
@@ -41,7 +41,6 @@ export class LookAtManager {
         }     
       }
     })
-    console.log(this.spineBones)
   }
 
   _getMouseDegrees (x, y, degreeLimit){
@@ -90,8 +89,6 @@ export class LookAtManager {
   }
 
   update(){
-    //console.log("new")
-    //console.log(this.curMousePos.x)
     this.neckBones.forEach(neck => {
       this._moveJoint(neck, this.maxLookPercent.neck)
     })

--- a/src/library/lookatManager.js
+++ b/src/library/lookatManager.js
@@ -54,7 +54,7 @@ export class LookAtManager {
     }
     setInterval(() => {
       this.update();
-    }, 1000/30);
+    }, 1000/60);
   }
   setCamera(camera){
     this.camera = camera

--- a/src/library/lookatManager.js
+++ b/src/library/lookatManager.js
@@ -1,0 +1,111 @@
+import * as THREE from 'three'
+
+export class LookAtManager {
+  constructor (){
+    this.neckBones = []
+    this.spineBones = []
+    this.leftEyeBones = []
+    this.rightEyesBones = []
+    this.curMousePos = {x:0,y:0}
+    this.maxLookPercent = {
+      neck: 20,
+      spine: 5,
+      left: 20,
+      right: 20,
+    }
+    window.addEventListener("mousemove", this.handleMouseMove)
+    setInterval(() => {
+      this.update();
+    }, 1000/30);
+  }
+
+  addVRM(vrm){
+    vrm.scene.traverse((child) => {
+      if (child.isBone) { 
+        switch (child.name){
+          case 'neck':
+            this.neckBones.push(child)
+            break
+          case 'spine':
+            this.spineBones.push(child)
+            break
+          case 'leftEye':
+            this.leftEyeBones.push(child)
+            break
+          case 'rightEye':
+            this.rightEyesBones.push(child)
+            break
+        }     
+      }
+    })
+  }
+
+  _getMouseDegrees (x, y, degreeLimit){
+    let dx = 0,
+      dy = 0,
+      xdiff,
+      xPercentage,
+      ydiff,
+      yPercentage
+
+    let w = { x: window.innerWidth, y: window.innerHeight }
+
+    if (x <= w.x / 2) {
+      // 2. Get the difference between middle of screen and cursor position
+      xdiff = w.x / 2 - x
+      // 3. Find the percentage of that difference (percentage toward edge of screen)
+      xPercentage = (xdiff / (w.x / 2)) * 100
+      // 4. Convert that to a percentage of the maximum rotation we allow for the neck
+      dx = ((degreeLimit * xPercentage) / 100) * -1
+    }
+    if (x >= w.x / 2) {
+      xdiff = x - w.x / 2
+      xPercentage = (xdiff / (w.x / 2)) * 100
+      dx = (degreeLimit * xPercentage) / 100
+    }
+    if (y <= w.y / 2) {
+      ydiff = w.y / 2 - y
+      yPercentage = (ydiff / (w.y / 2)) * 100
+      // Note that I cut degreeLimit in half when she looks up
+      dy = ((degreeLimit * 0.5 * yPercentage) / 100) * -1
+    }
+    if (y >= w.y / 2) {
+      ydiff = y - w.y / 2
+      yPercentage = (ydiff / (w.y / 2)) * 100
+      dy = (degreeLimit * yPercentage) / 100
+    }
+    return { x: dx, y: dy }
+  }
+
+  handleMouseMove (event) {
+    this.curMousePos = {x: event.x, y: event.y}
+    //setMousePosition({x: event.x, y: event.y});
+    // const moveJoint = (mouse, joint, degreeLimit) => {
+      
+    // }
+  }
+
+  _moveJoint(joint, degreeLimit){
+    if (Object.keys(joint).length !== 0) {
+      let degrees = this._getMouseDegrees(this.curMousePos.x, this.curMousePos.y, degreeLimit)
+      joint.rotation.y = THREE.MathUtils.degToRad(degrees.x)
+      joint.rotation.x = THREE.MathUtils.degToRad(degrees.y)
+    }
+  }
+
+  update(){
+    console.log("new")
+    this.neckBones.forEach(neck => {
+      this._moveJoint(neck, this.maxLookPercent.neck)
+    })
+    this.spineBones.forEach(spine => {
+      this._moveJoint(spine, this.maxLookPercent.spine)
+    })
+    this.leftEyeBones.forEach(leftEye => {
+      this._moveJoint(leftEye, this.maxLookPercent.left)
+    })
+    this.rightEyesBones.forEach(rightEye => {
+      this._moveJoint(rightEye, this.maxLookPercent.right)
+    })
+  }
+}

--- a/src/library/lookatManager.js
+++ b/src/library/lookatManager.js
@@ -22,10 +22,6 @@ export class LookAtManager {
     }, 1000/30);
   }
 
-
-  testCall(){
-    console.log("test")
-  }
   addVRM(vrm){
     vrm.scene.traverse((child) => {
       if (child.isBone) { 
@@ -45,6 +41,7 @@ export class LookAtManager {
         }     
       }
     })
+    console.log(this.spineBones)
   }
 
   _getMouseDegrees (x, y, degreeLimit){

--- a/src/library/lookatManager.js
+++ b/src/library/lookatManager.js
@@ -12,22 +12,16 @@ export class LookAtManager {
     this.enabled = true
     this.lookInterest = 1
     this.hasInterest = true
-    this.interestSpeed = 0.2
+    this.interestSpeed = 0.3
 
     this.clock = new THREE.Clock()
     this.deltaTime = 0
     
-    // this.maxLookPercent = {
-    //   neck: 20,
-    //   spine: 5,
-    //   left: 20,
-    //   right: 20,
-    // }
     this.maxLookPercent = {
       neck: 40,
       spine: 20,
-      left: 80,
-      right: 80,
+      left: 60,
+      right: 60,
     }
     window.addEventListener("mousemove", (e)=>{
         this.curMousePos = {x:e.clientX, y: e.clientY}

--- a/src/library/lookatManager.js
+++ b/src/library/lookatManager.js
@@ -21,10 +21,10 @@ export class LookAtManager {
     this.camera = null;
     
     this.maxLookPercent = {
-      neck: {max:30, min:10},
-      spine: {max:30, min:10},
-      left: {max:35, min:35},
-      right: {max:35, min:35},
+      neck: {maxy:15, miny:10,maxx:30, minx:10},
+      spine: {maxy:0, miny:0,maxx:30, minx:10},
+      left: {maxy:15, miny:20,maxx:35, minx:35},
+      right: {maxy:15, miny:20,maxx:35, minx:35},
     }
     window.addEventListener("mousemove", (e)=>{
         this.curMousePos = {x:e.clientX, y: e.clientY}
@@ -90,34 +90,31 @@ export class LookAtManager {
       yPercentage
 
     let w = { x: window.innerWidth, y: window.innerHeight }
-
     if (x <= w.x / 2) {
       // 2. Get the difference between middle of screen and cursor position
       xdiff = w.x / 2 - x
       // 3. Find the percentage of that difference (percentage toward edge of screen)
-      xPercentage = (xdiff / (w.x / 2)) * 100
+      xPercentage = ((xdiff / (w.x / 2)) ) * 100
       // 4. Convert that to a percentage of the maximum rotation we allow for the neck
-      dx = ((degreeLimit.max * xPercentage) / 100) * -1
+      dx = ((degreeLimit.maxx * xPercentage) / 100) * -1
     }
     if (x >= w.x / 2) {
       xdiff = x - w.x / 2
-      xPercentage = (xdiff / (w.x / 2)) * 100
-      dx = (degreeLimit.min * xPercentage) / 100
+      xPercentage = ((xdiff / (w.x / 2))) * 100
+      dx = (degreeLimit.minx * xPercentage) / 100
     }
 
     if (y <= w.y / 2) {
       ydiff = w.y / 2 - y
       yPercentage = (ydiff / (w.y / 2)) * 100
       // Note that I cut degreeLimit in half when she looks up
-      dy = ((degreeLimit.max * 0.5 * yPercentage) / 100) * -1
+      dy = ((degreeLimit.maxy * 0.5 * yPercentage) / 100) * -1
     }
     if (y >= w.y / 2) {
       ydiff = y - w.y / 2
       yPercentage = (ydiff / (w.y / 2)) * 100
-      dy = ((degreeLimit.min) * yPercentage) / 100
+      dy = ((degreeLimit.miny) * yPercentage) / 100
     }
-
-
     return { x: dx, y: dy }
   }
 
@@ -125,7 +122,7 @@ export class LookAtManager {
     if (Object.keys(joint).length !== 0) {
       const ymodifier = (this.camera.position.y - 1.8) * window.innerHeight/2;
       let degrees = this._getMouseDegrees(this.curMousePos.x, this.curMousePos.y - ymodifier, degreeLimit)
-      joint.rotation.y = THREE.MathUtils.degToRad(degrees.x) * this.lookInterest
+      joint.rotation.y = (THREE.MathUtils.degToRad(degrees.x) + this.camera.rotation.y/3) * this.lookInterest * speedMult
       joint.rotation.x = THREE.MathUtils.degToRad(degrees.y) * this.lookInterest
     }
   }
@@ -133,6 +130,7 @@ export class LookAtManager {
   _setInterest(){
     if (this.curMousePos.x > this.hotzoneSection.xStart && this.curMousePos.x < this.hotzoneSection.xEnd &&
         this.curMousePos.y > this.hotzoneSection.yStart && this.curMousePos.y < this.hotzoneSection.yEnd &&
+        this.camera.position.z > -2 && 
         this.onCanvas)
       this.hasInterest = true
     else
@@ -160,6 +158,7 @@ export class LookAtManager {
       this.spineBones.forEach(spine => {
         this._moveJoint(spine, this.maxLookPercent.spine)
       })
+      // eyes turn faster
       this.leftEyeBones.forEach(leftEye => {
         this._moveJoint(leftEye, this.maxLookPercent.left)
       })

--- a/src/library/lookatManager.js
+++ b/src/library/lookatManager.js
@@ -1,22 +1,27 @@
 import * as THREE from 'three'
 
 export class LookAtManager {
-  constructor (){
+  constructor (screenViewPercentage){
     this.neckBones = []
     this.spineBones = []
     this.leftEyeBones = []
     this.rightEyesBones = []
     this.curMousePos = new THREE.Vector2()
+    this.hotzoneWidth  = window.innerWidth * screenViewPercentage / 100
     this.maxLookPercent = {
       neck: 20,
       spine: 5,
       left: 20,
       right: 20,
     }
+    
     window.addEventListener("mousemove", (e)=>{
         this.curMousePos.x= e.clientX
         this.curMousePos.y= e.clientY
     })
+    window.addEventListener("resize", () => {
+      this.hotzoneWidth  = window.innerWidth * screenViewPercentage / 100;
+    });
     setInterval(() => {
       this.update();
     }, 1000/30);

--- a/src/library/lookatManager.js
+++ b/src/library/lookatManager.js
@@ -43,7 +43,12 @@ export class LookAtManager {
     function getHotzoneSection(){
       const width = window.innerWidth * screenViewPercentage / 100
       const halfLimit = (window.innerWidth - width) / 2
-      return {xStart: halfLimit, xEnd: window.innerWidth-halfLimit}
+      return {
+        xStart: halfLimit, 
+        xEnd: window.innerWidth-halfLimit, 
+        yStart: 50, 
+        yEnd: window.innerHeight-80
+      }
     }
     setInterval(() => {
       this.update();
@@ -117,7 +122,9 @@ export class LookAtManager {
   }
 
   _setInterest(){
-    if (this.curMousePos.x > this.hotzoneSection.xStart && this.curMousePos.x < this.hotzoneSection.xEnd && this.onCanvas)
+    if (this.curMousePos.x > this.hotzoneSection.xStart && this.curMousePos.x < this.hotzoneSection.xEnd &&
+        this.curMousePos.y > this.hotzoneSection.yStart && this.curMousePos.y < this.hotzoneSection.yEnd &&
+        this.onCanvas)
       this.hasInterest = true
     else
       this.hasInterest = false

--- a/src/library/lookatManager.js
+++ b/src/library/lookatManager.js
@@ -1,7 +1,7 @@
 import * as THREE from 'three'
 
 export class LookAtManager {
-  constructor (screenViewPercentage){
+  constructor (screenViewPercentage, canvasID){
     this.neckBones = []
     this.spineBones = []
     this.leftEyeBones = []
@@ -16,6 +16,7 @@ export class LookAtManager {
 
     this.clock = new THREE.Clock()
     this.deltaTime = 0
+    this.onCanvas = true;
     
     this.maxLookPercent = {
       neck: 40,
@@ -26,6 +27,15 @@ export class LookAtManager {
     window.addEventListener("mousemove", (e)=>{
         this.curMousePos = {x:e.clientX, y: e.clientY}
     })
+    const canvasRef = document.getElementById(canvasID)
+    if (canvasRef){
+      canvasRef.addEventListener("mouseleave", ()=>{
+        this.onCanvas = false;
+      })
+      canvasRef.addEventListener("mouseenter", ()=>{
+        this.onCanvas = true;
+      })
+    }
     window.addEventListener("resize", () => {
       this.hotzoneSection  = getHotzoneSection()
     });
@@ -107,7 +117,7 @@ export class LookAtManager {
   }
 
   _setInterest(){
-    if (this.curMousePos.x > this.hotzoneSection.xStart && this.curMousePos.x < this.hotzoneSection.xEnd)
+    if (this.curMousePos.x > this.hotzoneSection.xStart && this.curMousePos.x < this.hotzoneSection.xEnd && this.onCanvas)
       this.hasInterest = true
     else
       this.hasInterest = false

--- a/src/library/lookatManager.js
+++ b/src/library/lookatManager.js
@@ -6,14 +6,17 @@ export class LookAtManager {
     this.spineBones = []
     this.leftEyeBones = []
     this.rightEyesBones = []
-    this.curMousePos = {x:0,y:0}
+    this.curMousePos = new THREE.Vector2()
     this.maxLookPercent = {
       neck: 20,
       spine: 5,
       left: 20,
       right: 20,
     }
-    window.addEventListener("mousemove", this.handleMouseMove)
+    window.addEventListener("mousemove", (e)=>{
+        this.curMousePos.x= e.clientX
+        this.curMousePos.y= e.clientY
+    })
     setInterval(() => {
       this.update();
     }, 1000/30);
@@ -77,14 +80,6 @@ export class LookAtManager {
     return { x: dx, y: dy }
   }
 
-  handleMouseMove (event) {
-    this.curMousePos = {x: event.x, y: event.y}
-    //setMousePosition({x: event.x, y: event.y});
-    // const moveJoint = (mouse, joint, degreeLimit) => {
-      
-    // }
-  }
-
   _moveJoint(joint, degreeLimit){
     if (Object.keys(joint).length !== 0) {
       let degrees = this._getMouseDegrees(this.curMousePos.x, this.curMousePos.y, degreeLimit)
@@ -94,7 +89,8 @@ export class LookAtManager {
   }
 
   update(){
-    console.log("new")
+    //console.log("new")
+    //console.log(this.curMousePos.x)
     this.neckBones.forEach(neck => {
       this._moveJoint(neck, this.maxLookPercent.neck)
     })

--- a/src/library/lookatManager.js
+++ b/src/library/lookatManager.js
@@ -23,8 +23,8 @@ export class LookAtManager {
     this.maxLookPercent = {
       neck: {max:30, min:10},
       spine: {max:30, min:10},
-      left: {max:30, min:30},
-      right: {max:30, min:30},
+      left: {max:35, min:35},
+      right: {max:35, min:35},
     }
     window.addEventListener("mousemove", (e)=>{
         this.curMousePos = {x:e.clientX, y: e.clientY}

--- a/src/library/lookatManager.js
+++ b/src/library/lookatManager.js
@@ -52,9 +52,9 @@ export class LookAtManager {
         yEnd: window.innerHeight-80
       }
     }
-    setInterval(() => {
-      this.update();
-    }, 1000/60);
+    // setInterval(() => {
+    //   this.update();
+    // }, 1000/60);
   }
   setCamera(camera){
     this.camera = camera

--- a/src/library/lookatManager.js
+++ b/src/library/lookatManager.js
@@ -22,6 +22,10 @@ export class LookAtManager {
     }, 1000/30);
   }
 
+
+  testCall(){
+    console.log("test")
+  }
   addVRM(vrm){
     vrm.scene.traverse((child) => {
       if (child.isBone) { 

--- a/src/library/lookatManager.js
+++ b/src/library/lookatManager.js
@@ -8,6 +8,7 @@ export class LookAtManager {
     this.rightEyesBones = []
     this.curMousePos = new THREE.Vector2()
     this.hotzoneWidth  = window.innerWidth * screenViewPercentage / 100
+    this.enabled = true
     this.maxLookPercent = {
       neck: 20,
       spine: 5,
@@ -15,9 +16,11 @@ export class LookAtManager {
       right: 20,
     }
     
+    window.addEventListener("click", ()=>{
+      this.enabled = !this.enabled
+    })
     window.addEventListener("mousemove", (e)=>{
-        this.curMousePos.x= e.clientX
-        this.curMousePos.y= e.clientY
+        this.curMousePos = {x:e.clientX, y: e.clientY}
     })
     window.addEventListener("resize", () => {
       this.hotzoneWidth  = window.innerWidth * screenViewPercentage / 100;
@@ -94,17 +97,19 @@ export class LookAtManager {
   }
 
   update(){
-    this.neckBones.forEach(neck => {
-      this._moveJoint(neck, this.maxLookPercent.neck)
-    })
-    this.spineBones.forEach(spine => {
-      this._moveJoint(spine, this.maxLookPercent.spine)
-    })
-    this.leftEyeBones.forEach(leftEye => {
-      this._moveJoint(leftEye, this.maxLookPercent.left)
-    })
-    this.rightEyesBones.forEach(rightEye => {
-      this._moveJoint(rightEye, this.maxLookPercent.right)
-    })
+    if (this.enabled){
+      this.neckBones.forEach(neck => {
+        this._moveJoint(neck, this.maxLookPercent.neck)
+      })
+      this.spineBones.forEach(spine => {
+        this._moveJoint(spine, this.maxLookPercent.spine)
+      })
+      this.leftEyeBones.forEach(leftEye => {
+        this._moveJoint(leftEye, this.maxLookPercent.left)
+      })
+      this.rightEyesBones.forEach(rightEye => {
+        this._moveJoint(rightEye, this.maxLookPercent.right)
+      })
+    }
   }
 }

--- a/src/library/lookatManager.js
+++ b/src/library/lookatManager.js
@@ -17,12 +17,14 @@ export class LookAtManager {
     this.clock = new THREE.Clock()
     this.deltaTime = 0
     this.onCanvas = true;
+
+    this.camera = null;
     
     this.maxLookPercent = {
-      neck: 40,
-      spine: 20,
-      left: 60,
-      right: 60,
+      neck: {max:30, min:10},
+      spine: {max:30, min:10},
+      left: {max:30, min:30},
+      right: {max:30, min:30},
     }
     window.addEventListener("mousemove", (e)=>{
         this.curMousePos = {x:e.clientX, y: e.clientY}
@@ -53,6 +55,9 @@ export class LookAtManager {
     setInterval(() => {
       this.update();
     }, 1000/30);
+  }
+  setCamera(camera){
+    this.camera = camera
   }
 
   addVRM(vrm){
@@ -92,30 +97,34 @@ export class LookAtManager {
       // 3. Find the percentage of that difference (percentage toward edge of screen)
       xPercentage = (xdiff / (w.x / 2)) * 100
       // 4. Convert that to a percentage of the maximum rotation we allow for the neck
-      dx = ((degreeLimit * xPercentage) / 100) * -1
+      dx = ((degreeLimit.max * xPercentage) / 100) * -1
     }
     if (x >= w.x / 2) {
       xdiff = x - w.x / 2
       xPercentage = (xdiff / (w.x / 2)) * 100
-      dx = (degreeLimit * xPercentage) / 100
+      dx = (degreeLimit.min * xPercentage) / 100
     }
+
     if (y <= w.y / 2) {
       ydiff = w.y / 2 - y
       yPercentage = (ydiff / (w.y / 2)) * 100
       // Note that I cut degreeLimit in half when she looks up
-      dy = ((degreeLimit * 0.5 * yPercentage) / 100) * -1
+      dy = ((degreeLimit.max * 0.5 * yPercentage) / 100) * -1
     }
     if (y >= w.y / 2) {
       ydiff = y - w.y / 2
       yPercentage = (ydiff / (w.y / 2)) * 100
-      dy = (degreeLimit * yPercentage) / 100
+      dy = ((degreeLimit.min) * yPercentage) / 100
     }
+
+
     return { x: dx, y: dy }
   }
 
   _moveJoint(joint, degreeLimit){
     if (Object.keys(joint).length !== 0) {
-      let degrees = this._getMouseDegrees(this.curMousePos.x, this.curMousePos.y, degreeLimit)
+      const ymodifier = (this.camera.position.y - 1.8) * window.innerHeight/2;
+      let degrees = this._getMouseDegrees(this.curMousePos.x, this.curMousePos.y - ymodifier, degreeLimit)
       joint.rotation.y = THREE.MathUtils.degToRad(degrees.x) * this.lookInterest
       joint.rotation.x = THREE.MathUtils.degToRad(degrees.y) * this.lookInterest
     }

--- a/src/library/lookatManager.js
+++ b/src/library/lookatManager.js
@@ -122,7 +122,7 @@ export class LookAtManager {
     if (Object.keys(joint).length !== 0) {
       const ymodifier = (this.camera.position.y - 1.8) * window.innerHeight/2;
       let degrees = this._getMouseDegrees(this.curMousePos.x, this.curMousePos.y - ymodifier, degreeLimit)
-      joint.rotation.y = (THREE.MathUtils.degToRad(degrees.x) + this.camera.rotation.y/3) * this.lookInterest * speedMult
+      joint.rotation.y = (THREE.MathUtils.degToRad(degrees.x) + this.camera.rotation.y/3) * this.lookInterest
       joint.rotation.x = THREE.MathUtils.degToRad(degrees.y) * this.lookInterest
     }
   }

--- a/src/library/lookatManager.js
+++ b/src/library/lookatManager.js
@@ -130,7 +130,7 @@ export class LookAtManager {
   _setInterest(){
     if (this.curMousePos.x > this.hotzoneSection.xStart && this.curMousePos.x < this.hotzoneSection.xEnd &&
         this.curMousePos.y > this.hotzoneSection.yStart && this.curMousePos.y < this.hotzoneSection.yEnd &&
-        this.camera.position.z > -2 && 
+        this.camera.position.z > -2 && this.enabled &&
         this.onCanvas)
       this.hasInterest = true
     else
@@ -151,20 +151,19 @@ export class LookAtManager {
     this.deltaTime = this.clock.getDelta()
     this._setInterest();
     
-    if (this.enabled){
+    //if (this.enabled){
       this.neckBones.forEach(neck => {
         this._moveJoint(neck, this.maxLookPercent.neck)
       })
       this.spineBones.forEach(spine => {
         this._moveJoint(spine, this.maxLookPercent.spine)
       })
-      // eyes turn faster
       this.leftEyeBones.forEach(leftEye => {
         this._moveJoint(leftEye, this.maxLookPercent.left)
       })
       this.rightEyesBones.forEach(rightEye => {
         this._moveJoint(rightEye, this.maxLookPercent.right)
       })
-    }
+    //}
   }
 }

--- a/src/pages/Appearance.jsx
+++ b/src/pages/Appearance.jsx
@@ -5,7 +5,7 @@ import { SceneContext } from "../context/SceneContext"
 import Editor from '../components/Editor';
 import CustomButton from '../components/custom-button'
 
-function Appearance({manifest, initialTraits, animationManager, blinkManager, effectManager, fetchNewModel}) {
+function Appearance({manifest, initialTraits, animationManager, blinkManager, lookatManager, effectManager, fetchNewModel}) {
     const { setViewMode } = React.useContext(ViewContext);
     const { resetAvatar, getRandomCharacter } = React.useContext(SceneContext)
     const { isLoading, isPlayingEffect, setIsPlayingEffect } = React.useContext(ViewContext)
@@ -43,7 +43,7 @@ function Appearance({manifest, initialTraits, animationManager, blinkManager, ef
                 <img className={"rotate"} src="ui/loading.svg"/>
             </div>
             <div className={"sectionTitle"}>Choose Appearance</div>
-            <Editor manifest = {manifest} animationManager={animationManager} initialTraits={initialTraits} blinkManager={blinkManager} effectManager={effectManager} fetchNewModel={fetchNewModel} />
+            <Editor manifest = {manifest} animationManager={animationManager} initialTraits={initialTraits} blinkManager={blinkManager} lookatManager={lookatManager} effectManager={effectManager} fetchNewModel={fetchNewModel} />
             <div className={styles.buttonContainer}>
                 <CustomButton
                     theme="light"


### PR DESCRIPTION
This pr will extract the logic from selector.jsx that has the character looking at mouse position and create a new lookAtManager.js script that will also detect when the mouse is out of a hotspot.

Works for issue #146

https://user-images.githubusercontent.com/1117257/216165701-3c88d2ca-4942-44db-872c-88d722951131.mp4

