### PR TITLE
Don't look at the mouse when avatar rotation ≥ ±90º

### DIFF
--- a/src/library/lookatManager.js
+++ b/src/library/lookatManager.js
@@ -1,5 +1,7 @@
 import * as THREE from 'three'
 
+const localVector = new THREE.Vector3();
+
 export class LookAtManager {
   constructor (screenViewPercentage, canvasID){
     this.neckBones = []
@@ -27,7 +29,7 @@ export class LookAtManager {
       right: {maxy:15, miny:20,maxx:35, minx:35},
     }
     window.addEventListener("mousemove", (e)=>{
-        this.curMousePos = {x:e.clientX, y: e.clientY}
+      this.curMousePos = {x:e.clientX, y: e.clientY}
     })
     const canvasRef = document.getElementById(canvasID)
     if (canvasRef){
@@ -128,9 +130,13 @@ export class LookAtManager {
   }
 
   _setInterest(){
+    localVector.set(0, 0, 1);
+    localVector.applyQuaternion(this.camera.quaternion);
+    const cameraRotationThreshold = localVector.z > 0.; // if camera rotation is not larger than 90
+    
     if (this.curMousePos.x > this.hotzoneSection.xStart && this.curMousePos.x < this.hotzoneSection.xEnd &&
         this.curMousePos.y > this.hotzoneSection.yStart && this.curMousePos.y < this.hotzoneSection.yEnd &&
-        this.camera.position.z > -2 && this.enabled &&
+        cameraRotationThreshold && this.enabled &&
         this.onCanvas)
       this.hasInterest = true
     else
@@ -148,6 +154,8 @@ export class LookAtManager {
   }
 
   update(){
+    
+    
     this.deltaTime = this.clock.getDelta()
     this._setInterest();
     


### PR DESCRIPTION
now we are using camera position to check if the avatar rotation is ≥ ±90º, but it does not work with some edge cases. In this PR, I use camera direction instead of position.

related: https://github.com/webaverse-studios/CharacterCreator/issues/214

issue:


https://user-images.githubusercontent.com/60634884/217936649-4291b71f-721e-4f34-8f90-c6e5b0dbe086.mp4

result:


https://user-images.githubusercontent.com/60634884/217936684-62ba97ac-f7c9-4c23-92de-1c64aaf71027.mp4

