### PR TITLE
Fix voice overlap

### DIFF
--- a/src/library/lipsync.js
+++ b/src/library/lipsync.js
@@ -44,6 +44,9 @@ export class LipSync {
     this.userSpeechAnalyzer.smoothingTimeConstant = 0.5
     this.userSpeechAnalyzer.fftSize = FFT_SIZE
 
+    if (this.mediaStreamSource)
+      this.mediaStreamSource.stop()
+
     this.audioContext.decodeAudioData(file).then((buffer) => {
         this.mediaStreamSource = this.audioContext.createBufferSource()
         this.mediaStreamSource.buffer = buffer


### PR DESCRIPTION
been trying to reduce sound in branch https://github.com/webaverse-studios/CharacterCreator/tree/mem/fix-voice instead of muting abruptly, but for some reason setting gain in audio to 0 is not working. This pr fixes the overlap audio by stopping the current playing audio, and playing the new one.

temporal fix for #263 (better to have it muted abruptly for now than having overlapping audio while i find the fade out audio solution)

https://user-images.githubusercontent.com/1117257/217973678-3482891a-7730-403e-bc53-4337a2738e39.mp4

