### PR TITLE
Restricted options issue

### DIFF
--- a/src/components/Selector.jsx
+++ b/src/components/Selector.jsx
@@ -344,6 +344,7 @@ export default function Selector({templateInfo, animationManager, blinkManager, 
     // now update uptions
     removeTraits.forEach(trait => {
       let removed = false;
+      updateCurrentTraitMap(trait, null);
       
       for (let i =0; i < options.length;i++){
         // find an option with the trait name 


### PR DESCRIPTION
There is a little bug with this PR https://github.com/webaverse-studios/CharacterCreator/pull/289
When we remove the restricted/conflicted trait, we should also remove it from the currentTrait map. Otherwise, sometimes we are not allowed to select the item that is not currently on avatar which does not make sense.

issue:


https://user-images.githubusercontent.com/60634884/217974426-210307b9-e1bb-4cd8-91ef-b384c3c4a169.mp4

result:


https://user-images.githubusercontent.com/60634884/217974611-5777ec20-cf1a-4edc-bf0c-48ec4b3fd592.mp4




