### PR TITLE
add default trait to currentTrait map

### DIFF
--- a/src/components/Selector.jsx
+++ b/src/components/Selector.jsx
@@ -167,13 +167,11 @@ export default function Selector({templateInfo, animationManager, blinkManager, 
         item:null,
         trait:templateInfo.traits.find((t) => t.name === currentTraitName)
       }
-      updateCurrentTraitMap(option.trait.trait, null)
     }
     else {
       if (currentTrait.get(option.trait.trait) === option.key) {
         return;
       }
-      updateCurrentTraitMap(option.trait.trait, option.key)
     }
     
     if (option.avatarIndex != null){
@@ -208,6 +206,9 @@ export default function Selector({templateInfo, animationManager, blinkManager, 
   
   // load options first
   const loadOptions = (options, filterRestrictions = true) => {
+    for (const option of options) {
+      updateCurrentTraitMap(option.trait.trait, option.key)
+    }
     // filter options by restrictions
 
     if (filterRestrictions)


### PR DESCRIPTION
we should also add default trait to currentTrait map. Otherwise, we could select the trait that is already on the avatar initially.

issue:


https://user-images.githubusercontent.com/60634884/218139930-4b541e54-19fa-43ce-bae3-e17a0432149c.mp4

result:


https://user-images.githubusercontent.com/60634884/218140519-4844df0a-0c8d-484f-b268-23746f4aa5f9.mp4

