### PR TITLE
Fix vrm1 to vrm0 converting issues.

### DIFF
--- a/src/components/ExportMenu.jsx
+++ b/src/components/ExportMenu.jsx
@@ -260,7 +260,7 @@ export const ExportMenu = () => {
         size={14}
         className={styles.button}
         onClick={() => {
-          downloadVRM(model, avatar, name, 4096, false)
+          downloadVRM(model, avatar, name, 4096, true)
           //download(model, name, "vrm")
         }}
       />

--- a/src/library/VRMExporterv0.js
+++ b/src/library/VRMExporterv0.js
@@ -1,4 +1,4 @@
-import { BufferAttribute, Euler } from "three";
+import { BufferAttribute, Euler, Vector3 } from "three";
 import { VRMExpressionPresetName } from "@pixiv/three-vrm";
 function ToOutputVRMMeta(vrmMeta, icon, outputImage) {
     return {
@@ -501,6 +501,15 @@ export default class VRMExporterv0 {
                 VRM: {
                     blendShapeMaster: {blendShapeGroups},
                     //firstPerson: vrmFirstPerson,
+                    firstPerson: {
+                        firstPersonBone: 44,
+                        firstPersonBoneOffset: new Vector3(),
+                        lookAtHorizontalInner: {curve: [0, 0, 0, 1, 1, 1, 1, 0], xRange: 90, yRange: 10},
+                        lookAtHorizontalOuter: {curve: [0, 0, 0, 1, 1, 1, 1, 0], xRange: 90, yRange: 10},
+                        lookAtTypeName: 'Bone',
+                        lookAtVerticalDown: {curve: [0, 0, 0, 1, 1, 1, 1, 0], xRange: 90, yRange: 10},
+                        lookAtVerticalUp: {curve: [0, 0, 0, 1, 1, 1, 1, 0], xRange: 90, yRange: 10},
+                    },
                     humanoid: vrmHumanoid,
                     lookAt: vrmLookAt,
                     meta: outputVrmMeta,

--- a/src/library/download-utils.js
+++ b/src/library/download-utils.js
@@ -169,13 +169,15 @@ function parseVRM (glbModel, avatar, isVrm0 = false){
       bone._worldPosition.z *= -1;
     })
     skinnedMesh.skeleton.bones.forEach(bone => {
-      if (bone.name !== 'root') {
+      if (bone.name !== 'root' && !bone.name.includes('Hair') && !bone.name.startsWith('Bone')) {
         bone.position.x = bone._worldPosition.x - bone.parent._worldPosition.x;
         bone.position.z = bone._worldPosition.z - bone.parent._worldPosition.z;
       }
     })
     skinnedMesh.skeleton.bones.forEach(bone => {
-      bone.updateMatrixWorld();
+      if (bone.name !== 'root' && !bone.name.includes('Hair') && !bone.name.startsWith('Bone')) {
+        bone.updateMatrixWorld();
+      }
     })
     skinnedMesh.skeleton.calculateInverses();
     skinnedMesh.skeleton.computeBoneTexture();

--- a/src/library/download-utils.js
+++ b/src/library/download-utils.js
@@ -1,4 +1,4 @@
-import { Group, MeshStandardMaterial, Color } from "three"
+import { Group, MeshStandardMaterial, Color, Vector3 } from "three"
 import { GLTFExporter } from "three/examples/jsm/exporters/GLTFExporter"
 import { cloneSkeleton, combine } from "./merge-geometry"
 import { getAvatarData } from "./utils"
@@ -152,12 +152,34 @@ function parseGLB (glbModel){
 
 function parseVRM (glbModel, avatar, isVrm0 = false){
   return new Promise((resolve) => {
-    const exporter = isVrm0 ? new VRMExporter() :  new VRMExporterv0()
+    const exporter = isVrm0 ? new VRMExporterv0() :  new VRMExporter()
     console.log(exporter)
     const vrmData = {
       ...getVRMBaseData(avatar),
       ...getAvatarData(glbModel, "CharacterCreator"),
     }
+    let skinnedMesh;
+    glbModel.traverse(child => {
+      if (child.isSkinnedMesh) skinnedMesh = child;
+    })
+    // debugger
+    skinnedMesh.skeleton.bones.forEach(bone => {
+      bone._worldPosition = bone.getWorldPosition(new Vector3());
+      bone._worldPosition.x *= -1;
+      bone._worldPosition.z *= -1;
+    })
+    skinnedMesh.skeleton.bones.forEach(bone => {
+      if (bone.name !== 'root') {
+        bone.position.x = bone._worldPosition.x - bone.parent._worldPosition.x;
+        bone.position.z = bone._worldPosition.z - bone.parent._worldPosition.z;
+      }
+    })
+    skinnedMesh.skeleton.bones.forEach(bone => {
+      bone.updateMatrixWorld();
+    })
+    skinnedMesh.skeleton.calculateInverses();
+    skinnedMesh.skeleton.computeBoneTexture();
+    skinnedMesh.skeleton.update();
     exporter.parse(vrmData, glbModel, (vrm) => {
       resolve(vrm)
     })

--- a/src/library/merge-geometry.js
+++ b/src/library/merge-geometry.js
@@ -8,6 +8,8 @@ export function cloneSkeleton(skinnedMesh) {
     const boneClones = new Map();
     for (const bone of skinnedMesh.skeleton.bones) {
         const clone = bone.clone(false);
+        // clone.position.x *= -1;
+        // clone.position.z *= -1;
         boneClones.set(bone, clone);
     }
     // Preserve original bone structure
@@ -49,7 +51,9 @@ function createMergedSkeleton(meshes, isVrm0 = false){
                         parentName: bone.parent?.type == "Bone" ? bone.parent.name:null
                     }   
                     if (isVrm0){
-                        boneData.boneInverses.scale(zxNeg)
+                        // boneData.boneInverses.scale(zxNeg)
+                        // bone.position.x *= -1;
+                        // bone.position.z *= -1;
                     }
                     index++
                     boneClones.set(bone.name, boneData);


### PR DESCRIPTION
Fix vrm1 to vrm0 converting issues:
- Fix wrong bone rotation.
- Add fake vrm0 `firstPerson lookAt` datas to bypass the block error checking on https://3d.kalidoface.com/