### PR TITLE
upgrade three.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "sepia-speechrecognition-polyfill": "^1.0.0",
     "short-uuid": "^4.2.0",
     "styled-components": "^5.3.1",
-    "three": "^0.146.0",
+    "three": "^0.148.0",
     "three-mesh-bvh": "^0.5.21",
     "use-sound": "^4.0.1",
     "vite-plugin-mkcert": "^1.10.1",


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX18GZNsJfkMMEQWvoayYJm3UeqOHAxqXA%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=Vcz-2xI)

If you run `npm i` on a fresh repo, it complains about dependency graph being out of sync. `@pixiv/three-vrm` expects `three.js >= 1.148`. I upgraded to `1.148` but `1.149` is also available. Let me know if i should fully upgrade

![image](https://user-images.githubusercontent.com/9278174/219442444-f49b37d0-60d7-4d22-964f-45e2d9bbbd9f.png)
