### PR TITLE
Fix vrm0/vrm1 metallic default value

### DIFF
--- a/src/library/VRMExporter.js
+++ b/src/library/VRMExporter.js
@@ -789,7 +789,6 @@ const toOutputMaterials = (uniqueMaterials, images) => {
               texCoord: 0, // TODO:
           } :
           undefined;
-          console.log(material.type)
       const metallicFactor = (() => {
           switch (material.type) {
               case MaterialType.MeshStandardMaterial:

--- a/src/library/VRMExporter.js
+++ b/src/library/VRMExporter.js
@@ -789,6 +789,7 @@ const toOutputMaterials = (uniqueMaterials, images) => {
               texCoord: 0, // TODO:
           } :
           undefined;
+          console.log(material.type)
       const metallicFactor = (() => {
           switch (material.type) {
               case MaterialType.MeshStandardMaterial:
@@ -796,7 +797,7 @@ const toOutputMaterials = (uniqueMaterials, images) => {
               case MaterialType.MeshBasicMaterial:
                   return 0;
               default:
-                  return 0.5;
+                  return 0;
           }
       })();
       const roughnessFactor = (() => {
@@ -806,7 +807,7 @@ const toOutputMaterials = (uniqueMaterials, images) => {
               case MaterialType.MeshBasicMaterial:
                   return 0.9;
               default:
-                  return 0.5;
+                  return 0.9;
           }
       })();
       return {

--- a/src/library/VRMExporterv0.js
+++ b/src/library/VRMExporterv0.js
@@ -795,7 +795,6 @@ const toOutputMaterials = (uniqueMaterials, images) => {
               texCoord: 0, // TODO:
           } :
           undefined;
-          console.log(material.type)
       const metallicFactor = (() => {
           switch (material.type) {
               case MaterialType.MeshStandardMaterial:

--- a/src/library/VRMExporterv0.js
+++ b/src/library/VRMExporterv0.js
@@ -795,6 +795,7 @@ const toOutputMaterials = (uniqueMaterials, images) => {
               texCoord: 0, // TODO:
           } :
           undefined;
+          console.log(material.type)
       const metallicFactor = (() => {
           switch (material.type) {
               case MaterialType.MeshStandardMaterial:
@@ -802,7 +803,7 @@ const toOutputMaterials = (uniqueMaterials, images) => {
               case MaterialType.MeshBasicMaterial:
                   return 0;
               default:
-                  return 0.5;
+                  return 0;
           }
       })();
       const roughnessFactor = (() => {
@@ -812,7 +813,7 @@ const toOutputMaterials = (uniqueMaterials, images) => {
               case MaterialType.MeshBasicMaterial:
                   return 0.9;
               default:
-                  return 0.5;
+                  return 0.9;
           }
       })();
       return {


### PR DESCRIPTION
As requested from feedback, metallic value should be 0, and roughness 0.9 by default to avoid wierd looking models in non supported toon shader platforms, fix for #342
